### PR TITLE
Remove declared throw

### DIFF
--- a/src/go.interpret.js
+++ b/src/go.interpret.js
@@ -58,9 +58,7 @@ interpret.root = (node, data, runtime) => {
 interpret.declare = (node, data, runtime) => {
   const value = interpret.node(node.value, data, runtime).value
   const variables = runtime['$'] = runtime['$'] || {}
-  if (node.name in variables) {
-    throw new Error("template variable already declared: $" + node.name)
-  }
+
   variables[node.name] = { value: value, from: node }
   return ""
 }


### PR DESCRIPTION
Hey Joe!

If merged this PR would remove a throw that happens if a variable is already declared.

React re-runs on render changes, so if something changes, there's a re-render, which could run the Abstrate template rendering functions.

As you might be able to predict by now, if we call the function twice with the same template, Abstrate ends up throwing on the statement I removed. I tried to make it not throw by passing in new runtimes and variables every time, but sadly that didn't work. Maybe the internal runtime gets polluted? We might be able to explore going in that direction instead of removing this check.

Regardless, I removed this check after some debugging in my `node_modules`, and that does make stuff go along just fine.

If not merged we'd likely need to find a work-around.

Cheers!